### PR TITLE
Refactor preprocessor checks to enable multiple backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 *.ipdb
 
 examples/win32/ImRichTe.*/
+/examples/win32/imrichtext_demo/.vs/imrichtext_demo/copilot-chat

--- a/README.md
+++ b/README.md
@@ -117,19 +117,20 @@ loaded by `ImRichText::LoadFonts` functions before rendering.
 
 ## Immediate Goals
 * Word wrapping support
+* Support for class/id with stylesheets
 * Maybe add `<center>` and `<font>` tags? (These are deprecated in HTML5)
 * Add support for `margin`
 * Add support for line style (solid, dotted, dashed) for `border`
 * Implement support for vertical/horizontal text alignment including baseline alignment (May need to use FreeType backend)
 * Integration example with [Clay layout library](https://github.com/nicbarker/clay?tab=readme-ov-file)
 * Roman numerals for numbered lists
-* Radial gradient fills for backgrounds
 * Tables (`<table>`, `<tr>`, `<th>`, `<td>` tags)
 
 ## Future Goals
 * Use a library (roll your own?) to lookup font(s) based on requirements i.e. fuzzy match on family, etc.
 * Internationalization support by integrating [Harfbuzz](https://github.com/harfbuzz/harfbuzz) (Unicode Bidir algo)
 * Add ways to remove C++ standard library dependencies
+* Radial gradient fills for backgrounds
 * Text effects like "glow", "shadow", etc.
 
 ## Non-Goals

--- a/examples/win32/imrichtext_demo/glfwgl3/imrichtext_demo.vcxproj
+++ b/examples/win32/imrichtext_demo/glfwgl3/imrichtext_demo.vcxproj
@@ -163,6 +163,9 @@
     <ClInclude Include="..\..\..\..\imrichtextimpl.h" />
     <ClInclude Include="..\..\..\..\imrichtextutils.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\README.md" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/examples/win32/imrichtext_demo/glfwgl3/imrichtext_demo.vcxproj.filters
+++ b/examples/win32/imrichtext_demo/glfwgl3/imrichtext_demo.vcxproj.filters
@@ -72,4 +72,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\..\README.md">
+      <Filter>Resource Files</Filter>
+    </None>
+  </ItemGroup>
 </Project>

--- a/imrichtext.h
+++ b/imrichtext.h
@@ -90,11 +90,7 @@ namespace ImRichText
 
     struct FontStyle
     {
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-        ImFont* font = nullptr;
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
-        BLFont* font = nullptr;
-#endif
+        void* font = nullptr; // Pointer to font object
         std::string_view family = IM_RICHTEXT_DEFAULT_FONTFAMILY;
         float size = 24.f;
         int32_t flags = FontStyleNone;
@@ -310,7 +306,8 @@ namespace ImRichText
     [[nodiscard]] RenderConfig* GetCurrentConfig();
     void PushConfig(const RenderConfig& config);
     void PopConfig();
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
     [[nodiscard]] RenderConfig* GetCurrentConfig(BLContext& context);
     void PushConfig(const RenderConfig& config, BLContext& context);
     void PopConfig(BLContext& context);
@@ -332,7 +329,8 @@ namespace ImRichText
     bool Show(const char* text, const char* end = nullptr);
     bool Show(std::size_t richTextId);
     bool ToggleOverlay();
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
     bool Show(BLContext& context, ImVec2 pos, const char* text, const char* end = nullptr);
     bool Show(BLContext& context, ImVec2 pos, std::size_t richTextId);
 #endif

--- a/imrichtextfont.cpp
+++ b/imrichtextfont.cpp
@@ -20,7 +20,8 @@ namespace ImRichText
         // Use sorted vector + lower_bound lookups?
 #ifdef IM_RICHTEXT_TARGET_IMGUI
         std::map<float, ImFont*> Fonts[FT_Total];
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
         std::map<float, BLFont> Fonts[FT_Total];
         BLFontFace FontFace[FT_Total];
 #endif
@@ -83,8 +84,8 @@ namespace ImRichText
         return true;
     }
 
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
-
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
     static void CreateFont(FontFamily& family, FontType ft, float size)
     {
         auto& face = family.FontFace[ft];
@@ -125,11 +126,8 @@ namespace ImRichText
     }
 #endif
 
-    static void LoadDefaultProportionalFont(float sz
 #ifdef IM_RICHTEXT_TARGET_IMGUI
-        , const ImFontConfig& fconfig
-#endif
-    )
+    static void LoadDefaultProportionalFont(float sz, const ImFontConfig& fconfig)
     {
 #ifdef _WIN32
         LoadFonts(IM_RICHTEXT_DEFAULT_FONTFAMILY, {
@@ -138,19 +136,12 @@ namespace ImRichText
             "c:\\Windows\\Fonts\\segoeuib.ttf",
             "c:\\Windows\\Fonts\\segoeuii.ttf",
             "c:\\Windows\\Fonts\\segoeuiz.ttf"
-            }, sz
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-            , fconfig);
-#endif
+            }, sz, fconfig);
 #endif
         // TODO: Add default fonts for other platforms
     }
 
-    void LoadDefaultMonospaceFont(float sz
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-        , const ImFontConfig& fconfig
-#endif
-    )
+    static void LoadDefaultMonospaceFont(float sz, const ImFontConfig& fconfig)
     {
 #ifdef _WIN32
         LoadFonts(IM_RICHTEXT_MONOSPACE_FONTFAMILY, {
@@ -159,20 +150,48 @@ namespace ImRichText
             "c:\\Windows\\Fonts\\consolab.ttf",
             "c:\\Windows\\Fonts\\consolai.ttf",
             "c:\\Windows\\Fonts\\consolaz.ttf"
-            }, sz
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-            , fconfig);
-#endif
+            }, sz, fconfig);
 #endif
         // TODO: Add default fonts for other platforms
     }
+#endif
+
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
+    static void LoadDefaultProportionalFont(float sz)
+    {
+#ifdef _WIN32
+        LoadFonts(IM_RICHTEXT_DEFAULT_FONTFAMILY, {
+            "c:\\Windows\\Fonts\\segoeui.ttf",
+            "c:\\Windows\\Fonts\\segoeuil.ttf",
+            "c:\\Windows\\Fonts\\segoeuib.ttf",
+            "c:\\Windows\\Fonts\\segoeuii.ttf",
+            "c:\\Windows\\Fonts\\segoeuiz.ttf"
+            }, sz);
+#endif
+        // TODO: Add default fonts for other platforms
+    }
+
+    static void LoadDefaultMonospaceFont(float sz)
+    {
+#ifdef _WIN32
+        LoadFonts(IM_RICHTEXT_MONOSPACE_FONTFAMILY, {
+            "c:\\Windows\\Fonts\\consola.ttf",
+            "",
+            "c:\\Windows\\Fonts\\consolab.ttf",
+            "c:\\Windows\\Fonts\\consolai.ttf",
+            "c:\\Windows\\Fonts\\consolaz.ttf"
+            }, sz);
+#endif
+        // TODO: Add default fonts for other platforms
+    }
+#endif
 
     bool LoadDefaultFonts(float sz, FontFileNames* names)
     {
 #ifdef IM_RICHTEXT_TARGET_IMGUI
         ImFontConfig fconfig;
-        fconfig.OversampleH = 2.0;
-        fconfig.OversampleV = 1.0;
+        fconfig.OversampleH = 2;
+        fconfig.OversampleV = 1;
         fconfig.RasterizerMultiply = sz <= 16.f ? 2.f : 1.f;
 #ifdef IMGUI_ENABLE_FREETYPE
         fconfig.FontBuilderFlags = ImGuiFreeTypeBuilderFlags_LightHinting;
@@ -191,7 +210,8 @@ namespace ImRichText
 #ifdef IM_RICHTEXT_TARGET_IMGUI
             LoadDefaultProportionalFont(sz, fconfig);
             LoadDefaultMonospaceFont(sz, fconfig);
-#elif defined(IM_RICHTEXT_TARGT_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
             LoadDefaultProportionalFont(sz);
             LoadDefaultMonospaceFont(sz);
 #endif
@@ -228,7 +248,8 @@ namespace ImRichText
                 files.Files[FT_BoldItalics] = copyFileName(names->Proportional.Files[FT_BoldItalics], fontpath, startidx);
 #ifdef IM_RICHTEXT_TARGET_IMGUI
                 LoadFonts(IM_RICHTEXT_DEFAULT_FONTFAMILY, files, sz, fconfig);
-#elif defined(IM_RICHTEXT_TARGT_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
                 LoadFonts(IM_RICHTEXT_DEFAULT_FONTFAMILY, files, sz);
 #endif
             }
@@ -236,7 +257,8 @@ namespace ImRichText
             {
 #ifdef IM_RICHTEXT_TARGET_IMGUI
                 LoadDefaultProportionalFont(sz, fconfig);
-#elif defined(IM_RICHTEXT_TARGT_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
                 LoadDefaultProportionalFont(sz);
 #endif
             }
@@ -249,7 +271,8 @@ namespace ImRichText
                 files.Files[FT_BoldItalics] = copyFileName(names->Monospace.Files[FT_BoldItalics], fontpath, startidx);
 #ifdef IM_RICHTEXT_TARGET_IMGUI
                 LoadFonts(IM_RICHTEXT_MONOSPACE_FONTFAMILY, files, sz, fconfig);
-#elif defined(IM_RICHTEXT_TARGT_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
                 LoadFonts(IM_RICHTEXT_MONOSPACE_FONTFAMILY, files, sz);
 #endif
             }
@@ -257,7 +280,8 @@ namespace ImRichText
             {
 #ifdef IM_RICHTEXT_TARGET_IMGUI
                 LoadDefaultMonospaceFont(sz, fconfig);
-#elif defined(IM_RICHTEXT_TARGT_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
                 LoadDefaultMonospaceFont(sz);
 #endif
             }
@@ -322,12 +346,7 @@ namespace ImRichText
         return famit;
     }
 
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-    ImFont* 
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
-    BLFont*
-#endif
-    GetFont(std::string_view family, float size, FontType ft, void*)
+    void* GetFont(std::string_view family, float size, FontType ft, void*)
     {
         auto famit = LookupFontFamily(family);
         const auto& fonts = famit->second.Fonts[ft];
@@ -342,12 +361,10 @@ namespace ImRichText
         return szit->second;
     }
 
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-    ImFont* GetOverlayFont(const RenderConfig& config)
+    void* GetOverlayFont(const RenderConfig& config)
     {
         auto it = LookupFontFamily(IM_RICHTEXT_DEFAULT_FONTFAMILY);
         auto fontsz = config.DefaultFontSize * 0.8f * config.FontScale;
         return it->second.Fonts->lower_bound(fontsz)->second;
     }
-#endif
 }

--- a/imrichtextfont.h
+++ b/imrichtextfont.h
@@ -39,7 +39,8 @@ namespace ImRichText
 
 #ifdef IM_RICHTEXT_TARGET_IMGUI
     bool LoadFonts(std::string_view family, const FontCollectionFile& files, float size, ImFontConfig config);
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
     bool LoadFonts(std::string_view family, const FontCollectionFile& files, float size);
 #endif
 
@@ -47,10 +48,6 @@ namespace ImRichText
     bool LoadDefaultFonts(const std::initializer_list<float>& szs, FontFileNames* names = nullptr);
     bool LoadDefaultFonts(const RenderConfig& config);
 
-#ifdef IM_RICHTEXT_TARGET_IMGUI
-    [[nodiscard]] ImFont* GetFont(std::string_view family, float size, FontType type, void*);
-    [[nodiscard]] ImFont* GetOverlayFont(const RenderConfig& config);
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
-    [[nodiscard]] BLFont* GetFont(std::string_view family, float size, FontType type, void*);
-#endif
+    [[nodiscard]] void* GetFont(std::string_view family, float size, FontType type, void*);
+    [[nodiscard]] void* GetOverlayFont(const RenderConfig& config);
 }

--- a/imrichtextimpl.cpp
+++ b/imrichtextimpl.cpp
@@ -197,7 +197,7 @@ namespace ImRichText
         auto font = GetFont(family, sz, type, nullptr);
 
         if (font != nullptr) {
-            ImGui::PushFont(font); return true;
+            ImGui::PushFont((ImFont*)font); return true;
         }
 
         return false;
@@ -236,7 +236,7 @@ namespace ImRichText
         auto font = GetFont(family, sz, type, nullptr);
 
         if (font != nullptr) {
-            ImGui::PushFont(font); popFont = true;
+            ImGui::PushFont((ImFont*)font); popFont = true;
         }
 
         ((ImDrawList*)UserData)->AddText(pos, color, text.data(), text.data() + text.size());
@@ -251,6 +251,11 @@ namespace ImRichText
             ImGui::SetTooltip("%.*s", (int)text.size(), text.data());
             ResetFont();
         }
+    }
+
+    float ImGuiRenderer::EllipsisWidth(void* fontptr)
+    {
+        return ((ImFont*)fontptr)->EllipsisWidth;
     }
 
     ImVec2 ImGuiPlatform::GetCurrentMousePos()

--- a/imrichtextimpl.h
+++ b/imrichtextimpl.h
@@ -39,6 +39,7 @@ namespace ImRichText
         void DrawText(std::string_view text, ImVec2 pos, uint32_t color);
         void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type);
         void DrawTooltip(ImVec2 pos, std::string_view text);
+        float EllipsisWidth(void* fontptr);
     };
 
     struct ImGuiPlatform final : public IPlatform
@@ -55,7 +56,8 @@ namespace ImRichText
         void HandleHover(bool hovered);
     };
 
-#elif defined(IM_RICHTEXT_TARGET_BLEND2D)
+#endif
+#ifdef IM_RICHTEXT_TARGET_BLEND2D
 
     struct Blend2DRenderer final : public IRenderer
     {
@@ -84,6 +86,7 @@ namespace ImRichText
         void DrawText(std::string_view text, ImVec2 pos, uint32_t color);
         void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type);
         void DrawTooltip(ImVec2 pos, std::string_view text);
+        float EllipsisWidth(void* fontptr);
     };
 
 #endif

--- a/imrichtextutils.cpp
+++ b/imrichtextutils.cpp
@@ -513,6 +513,7 @@ namespace ImRichText
             { "lightslategrey", ToRGBA(119, 136, 153) },
             { "lightsteelblue", ToRGBA(176, 196, 222) },
             { "lightyellow", ToRGBA(255, 255, 224) },
+            { "lilac", ToRGBA(200, 162, 200) },
             { "limegreen", ToRGBA(50, 255, 50) },
             { "linen", ToRGBA(250, 240, 230) },
             { "mediumaquamarine", ToRGBA(102, 205, 170) },
@@ -647,6 +648,7 @@ namespace ImRichText
         }
         else
             result.color = ExtractColor(input.substr(prev, idx), NamedColor, userData);
+        return result;
     }
     
     std::pair<std::string_view, bool> ExtractTag(const char* text, int end, char TagEnd,

--- a/imrichtextutils.h
+++ b/imrichtextutils.h
@@ -103,6 +103,7 @@ namespace ImRichText
         virtual void DrawText(std::string_view text, ImVec2 pos, uint32_t color) = 0;
         virtual void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type) = 0;
         virtual void DrawTooltip(ImVec2 pos, std::string_view text) = 0;
+        virtual float EllipsisWidth(void* fontptr) = 0;
 
         void DrawDefaultBullet(BulletType type, ImVec2 initpos, const BoundedBox& bounds, uint32_t color, float bulletsz);
     };


### PR DESCRIPTION
Existing implementation expected either of ImGui or Blend2D backends to work. With this change, both can be enabled if both the macros (`IM_RICHTEXT_TARGET_IMGUI` and `IM_RICHTEXT_TARGET_BLEND2D`) are defined. In future more backends can be supported.