### PR TITLE
Implement auto-scaling of fonts for ImGui backend

### DIFF
--- a/imrichtext.h
+++ b/imrichtext.h
@@ -198,7 +198,7 @@ namespace ImRichText
 
     struct DrawableBlock
     {
-        ImVec2 Start{ -1.f, -1.f }, End{ -1.f, -1.f };
+        ImVec2 Start{ -1.f, -1.f }, End{ -1.f, -1.f }, ViewportPos{ 0.f, 0.f };
         uint32_t Color = IM_COL32_BLACK_TRANS;
         FourSidedMeasure padding;
         FourSidedMeasure margin;

--- a/imrichtextfont.h
+++ b/imrichtextfont.h
@@ -56,6 +56,7 @@ namespace ImFontManager
     {
         FLT_Proportional = 1,
         FLT_Monospace = 2,
+
         FLT_HasSmall = 4,
         FLT_HasSuperscript = 8,
         FLT_HasSubscript = 16,
@@ -65,6 +66,12 @@ namespace ImFontManager
         FLT_HasH4 = 256,
         FLT_HasH5 = 512,
         FLT_HasH6 = 1024,
+
+        // Use this to auto-scale fonts, loading the largest size for a family
+        // NOTE: For ImGui backend, this will save on memory from texture
+        FLT_AutoScale = 2048, 
+
+        // Include all <h*> tags
         FLT_HasHeaders = FLT_HasH1 | FLT_HasH2 | FLT_HasH3 | FLT_HasH4 | FLT_HasH5 | FLT_HasH6,
 
         // TODO: Handle absolute size font-size fonts (Look at imrichtext.cpp: PopulateSegmentStyle function)
@@ -109,7 +116,7 @@ namespace ImFontManager
     // ImFont* cast to void* to better fit overall library.
     // NOTE: size matching happens with lower_bound calls, this is done because all fonts
     //       should be preloaded for ImGui, dynamic font atlas updates are not supported.
-    [[nodiscard]] void* GetFont(std::string_view family, float size, FontType type, void*);
+    [[nodiscard]] void* GetFont(std::string_view family, float size, FontType type);
 
 #ifndef IM_FONTMANAGER_STANDALONE
     // Get font to display overlay i.e. style info in side panel
@@ -131,6 +138,6 @@ namespace ImFontManager
     // BLFont* cast to void* to better fit overall library.
     // NOTE: The FontExtraInfo::mapper can be assigned to a function which loads fonts based
     //       con content codepoints and can perform better fallback.
-    [[nodiscard]] void* GetFont(std::string_view family, float size, FontType type, FontExtraInfo extra, void*);
+    [[nodiscard]] void* GetFont(std::string_view family, float size, FontType type, FontExtraInfo extra);
 #endif
 }

--- a/imrichtextimpl.h
+++ b/imrichtextimpl.h
@@ -71,13 +71,17 @@ namespace ImRichText
         void DrawRadialGradient(ImVec2 center, float radius, uint32_t in, uint32_t out, int start, int end);
 
         bool SetCurrentFont(std::string_view family, float sz, FontType type) override;
-        bool SetCurrentFont(void* fontptr) override;
+        bool SetCurrentFont(void* fontptr, float sz) override;
         void ResetFont() override;
-        [[nodiscard]] ImVec2 GetTextSize(std::string_view text, void* fontptr);
+        [[nodiscard]] ImVec2 GetTextSize(std::string_view text, void* fontptr, float sz);
         void DrawText(std::string_view text, ImVec2 pos, uint32_t color);
         void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type);
         void DrawTooltip(ImVec2 pos, std::string_view text);
-        [[nodiscard]] float EllipsisWidth(void* fontptr) override;
+        [[nodiscard]] float EllipsisWidth(void* fontptr, float sz) override;
+
+    private:
+
+        float _currentFontSz = 0.f;
     };
 
     struct ImGuiPlatform final : public IPlatform
@@ -119,9 +123,9 @@ namespace ImRichText
         void DrawRadialGradient(ImVec2 center, float radius, uint32_t in, uint32_t out, int start, int end);
 
         bool SetCurrentFont(std::string_view family, float sz, FontType type) override;
-        bool SetCurrentFont(void* fontptr) override;
+        bool SetCurrentFont(void* fontptr, float sz) override;
         void ResetFont() override;
-        ImVec2 GetTextSize(std::string_view text, void* fontptr);
+        ImVec2 GetTextSize(std::string_view text, void* fontptr, float sz);
         void DrawText(std::string_view text, ImVec2 pos, uint32_t color);
         void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type);
         void DrawTooltip(ImVec2 pos, std::string_view text);

--- a/imrichtextutils.cpp
+++ b/imrichtextutils.cpp
@@ -909,9 +909,9 @@ namespace ImRichText
         visitor.Finalize();
     }
 
-    float IRenderer::EllipsisWidth(void* fontptr)
+    float IRenderer::EllipsisWidth(void* fontptr, float sz)
     {
-        return GetTextSize("...", fontptr).x;
+        return GetTextSize("...", fontptr, sz).x;
     }
 
     void IRenderer::DrawDefaultBullet(BulletType type, ImVec2 initpos, const BoundedBox& bounds, uint32_t color, float bulletsz)

--- a/imrichtextutils.h
+++ b/imrichtextutils.h
@@ -157,14 +157,14 @@ namespace ImRichText
         virtual void DrawBullet(ImVec2 startpos, ImVec2 endpos, uint32_t color, int index, int depth) {};
         
         virtual bool SetCurrentFont(std::string_view family, float sz, FontType type) { return false; };
-        virtual bool SetCurrentFont(void* fontptr) { return false; };
+        virtual bool SetCurrentFont(void* fontptr, float sz) { return false; };
         virtual void ResetFont() {};
 
-        virtual ImVec2 GetTextSize(std::string_view text, void* fontptr) = 0;
+        virtual ImVec2 GetTextSize(std::string_view text, void* fontptr, float sz) = 0;
         virtual void DrawText(std::string_view text, ImVec2 pos, uint32_t color) = 0;
         virtual void DrawText(std::string_view text, std::string_view family, ImVec2 pos, float sz, uint32_t color, FontType type) = 0;
         virtual void DrawTooltip(ImVec2 pos, std::string_view text) = 0;
-        virtual float EllipsisWidth(void* fontptr);
+        virtual float EllipsisWidth(void* fontptr, float sz);
 
         void DrawDefaultBullet(BulletType type, ImVec2 initpos, const BoundedBox& bounds, uint32_t color, float bulletsz);
     };
@@ -184,6 +184,7 @@ namespace ImRichText
         struct WordProperty
         {
             void* font;
+            float sz;
             WordBreakBehavior wb;
         };
 


### PR DESCRIPTION
This changes contains the necessary API changes required and uses `ImDrawList::AddText` overload to implement scaled text based on loaded font.

closes #30 